### PR TITLE
Ignore transaction errors with status < 500

### DIFF
--- a/lib/new_relic/phoenix/instrumenter.ex
+++ b/lib/new_relic/phoenix/instrumenter.ex
@@ -16,6 +16,7 @@ defmodule NewRelic.Phoenix.Instrumenter do
   def phoenix_error_render(:stop, _time_diff, {conn, status, error}) do
     NewRelic.add_attributes(status: status)
     NewRelic.Phoenix.Transaction.Plug.before_send(conn)
+
     if status >= 500 do
       NewRelic.Transaction.Reporter.fail(error)
     end

--- a/lib/new_relic/phoenix/instrumenter.ex
+++ b/lib/new_relic/phoenix/instrumenter.ex
@@ -16,6 +16,8 @@ defmodule NewRelic.Phoenix.Instrumenter do
   def phoenix_error_render(:stop, _time_diff, {conn, status, error}) do
     NewRelic.add_attributes(status: status)
     NewRelic.Phoenix.Transaction.Plug.before_send(conn)
-    NewRelic.Transaction.Reporter.fail(error)
+    if status >= 500 do
+      NewRelic.Transaction.Reporter.fail(error)
+    end
   end
 end


### PR DESCRIPTION
Adds a simple conditional to not report errors when the HTTP status is < 500.