### PR TITLE
Don't include URL in Transaction name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### `v0.3.1`
+
+* Don't include full URL in Transaction name, it just leads to Metric Explosions.
+
 ### `v0.3.0`
 
 * Fix to work with latest agent version. [#16](https://github.com/binaryseed/new_relic_phoenix/pull/16) Thanks @claudioStahl!

--- a/lib/new_relic/phoenix/transaction/plug.ex
+++ b/lib/new_relic/phoenix/transaction/plug.ex
@@ -39,7 +39,7 @@ defmodule NewRelic.Phoenix.Transaction.Plug do
   end
 
   def set_framework_name(%{private: %{phoenix_endpoint: endpoint}} = conn) do
-    NewRelic.add_attributes(framework_name: "/Phoenix/#{inspect(endpoint)}#{conn.request_path}")
+    NewRelic.add_attributes(framework_name: "/Phoenix/#{inspect(endpoint)}")
   end
 
   def set_framework_name(_), do: :ignore

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule NewRelicPhoenix.MixProject do
     [
       app: :new_relic_phoenix,
       description: "New Relic Instrumentation adapter for Phoenix",
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       name: "New Relic Phoenix",

--- a/test/new_relic_phoenix_test.exs
+++ b/test/new_relic_phoenix_test.exs
@@ -87,7 +87,7 @@ defmodule NewRelicPhoenixTest do
     assert tx_event[:status] == 404
     assert tx_event[:path] == "/not_found"
     assert tx_event[:error] == nil
-    assert tx_event[:framework_name] == "/Phoenix/NewRelicPhoenixTest.TestEndpoint/not_found"
+    assert tx_event[:framework_name] == "/Phoenix/NewRelicPhoenixTest.TestEndpoint"
     assert tx_event[:"phoenix.controller"] == nil
   end
 


### PR DESCRIPTION
Quick fix to prevent Metric Explosions